### PR TITLE
Make sure column names in subquery are unique

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -130,7 +130,7 @@ module.exports = (function() {
       for (key in valueHash) {
         //wtm - added to allow ability to turn omitNull to false
         //if we had omit null as true we would diable inserting
-        //undefined values as null, we enable this ability 
+        //undefined values as null, we enable this ability
         //by setting omitNull to false, but then, autoIncrement
         //no longer works in sequelize.
         if(key === 'id') {
@@ -568,7 +568,7 @@ module.exports = (function() {
           })
         } else {
           mainAttributes.push("id")
-        }          
+        }
       }
 
       // Escape attributes
@@ -727,7 +727,7 @@ module.exports = (function() {
 
             if (subQuery && !include.subQuery && include.parent.subQuery) {
               //wtm - force quote the "as"
-              where = self.options.quoteIdentifers ? self.quoteIdentifier(tableLeft + "." + attrLeft) + " = " : self.quoteIdentifier(tableLeft, true) + "." + attrLeft 
+              where = self.options.quoteIdentifers ? self.quoteIdentifier(tableLeft + "." + attrLeft) + " = " : self.quoteIdentifier(tableLeft, true) + "." + attrLeft
             } else {
               if(subQuery) {
                 //wtm - force quote the "as"
@@ -792,7 +792,7 @@ module.exports = (function() {
 
       // If using subQuery select defined subQuery attributes and join subJoinQueries
       if (subQuery) {
-        subQueryItems.push("SELECT " + subQueryAttributes.join(', ') + " FROM " + options.table)
+        subQueryItems.push("SELECT " + Utils._.uniq(subQueryAttributes).join(', ') + " FROM " + options.table)
         subQueryItems.push(subJoinQueries.join(''))
 
       // Else do it the reguar way
@@ -820,7 +820,7 @@ module.exports = (function() {
           mainQueryItems.push(" GROUP BY " + options.group)
         }
       }
-      
+
       // Add HAVING to sub or main query
       if (options.hasOwnProperty('having')) {
         options.having = this.getWhereConditions(options.having, tableName, factory, options, false)
@@ -846,7 +846,7 @@ module.exports = (function() {
         } else {
           mainQueryOrder.push(options.order)
         }
-        
+
         if (mainQueryOrder.length) {
           mainQueryItems.push(" ORDER BY " + mainQueryOrder.join(', '))
         }


### PR DESCRIPTION
The basic issue was that the query generated for a limit with includes was duplicating the join column in the main object sub query. See example below. My change just makes sure the column names in the subquery are unique.

``` sql
SELECT "account_1738.wtm_discounts".*, wtm_pos_discount_mapsmaster_id.pos_name AS "wtm_pos_discount_mapsmaster_id.pos_name", wtm_pos_discount_mapsmaster_id.pos_id AS "wtm_pos_discount_mapsmaster_id.pos_id", wtm_pos_discount_mapsmaster_id.id AS "wtm_pos_discount_mapsmaster_id.id", wtm_pos_discount_mapsmaster_id.created_by AS "wtm_pos_discount_mapsmaster_id.created_by", wtm_pos_discount_mapsmaster_id.created_at AS "wtm_pos_discount_mapsmaster_id.created_at", wtm_pos_discount_mapsmaster_id.updated_by AS "wtm_pos_discount_mapsmaster_id.updated_by", wtm_pos_discount_mapsmaster_id.updated_at AS "wtm_pos_discount_mapsmaster_id.updated_at", wtm_pos_discount_mapsmaster_id.is_deleted AS "wtm_pos_discount_mapsmaster_id.is_deleted", wtm_pos_discount_mapsmaster_id.location_id AS "wtm_pos_discount_mapsmaster_id.location_id", wtm_pos_discount_mapsmaster_id.master_id AS "wtm_pos_discount_mapsmaster_id.master_id" 
FROM 
(SELECT account_1738.wtm_discounts.name, account_1738.wtm_discounts.id, account_1738.wtm_discounts.created_by, account_1738.wtm_discounts.created_at, account_1738.wtm_discounts.updated_by, account_1738.wtm_discounts.updated_at, account_1738.wtm_discounts.id FROM account_1738.wtm_discounts WHERE account_1738.wtm_discounts.is_deleted=false LIMIT 29) AS "account_1738.wtm_discounts"
 LEFT OUTER JOIN account_1738.wtm_pos_discount_maps AS "wtm_pos_discount_mapsmaster_id" ON "account_1738.wtm_discounts".id = "wtm_pos_discount_mapsmaster_id".master_id;
```
